### PR TITLE
Fixed issue #3

### DIFF
--- a/src/test/java/com/h2/Module3_Test.java
+++ b/src/test/java/com/h2/Module3_Test.java
@@ -363,6 +363,6 @@ public class Module3_Test {
         Method method = savingsCalculator.getMethod("main", String[].class);
         method.invoke(null, (Object) new String[]{credits, debits});
 
-        assertEquals("Net Savings = 5.0, remaining days in month = " + remainingDays + "\n", testOut.toString());
+        assertEquals("Net Savings = 5.0, remaining days in month = " + remainingDays + System.lineSeparator(), testOut.toString());
     }
 }


### PR DESCRIPTION
Module3_Test fails on Windows and pass on Linux/Mac

The hardcoded symbols of new line should be replaced with System.lineSeparator()

assertEquals("Net Savings = 5.0, remaining days in month = " + remainingDays + System.lineSeparator(), testOut.toString());